### PR TITLE
Document the sortable property & make it work on default sort columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ These objects also have several optional attributes that can make the cells disp
   - You must pass this to the table as a callbacks object with the key as the `accessor` and you function as the value. 
 - **sortType**: This allows you to pass an additional sort type
   - currently only the allowed option is 'date' and that sorts assuming the date format is `mm/dd/yyyy`
+- **sortable**: This allows you to disable the sort function for a column. 
+  - `true` (default): Clicking on the column header will sort by that column
+  - `false`: Clicking on the column header will have no effect
 
 ##### showSearch (default: false)
 This is a boolean to tell the table whether or not show the search component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-collapsing-table",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "react-collapsing-table: a React rewrite of the jQuery table plugin from 'datatables.net'. Inspired by a lack of similar table behaviors, notably collapsibility and responsivity.",
   "main": "build/index.js",
   "peerDependencies": {

--- a/src/actions/TableActions.js
+++ b/src/actions/TableActions.js
@@ -52,8 +52,8 @@ export const changeSortFieldAndDirection = ({ newColumn, state }) => {
 export const changeRowOrder = ({ column, state }) => {
     const { sort: { direction }, columns } = state;
     let rows = state.rows;
-    const [ columnBeingSorted, ...b ] = columns.filter(c => c.accessor === column);
-    const type = columnBeingSorted ? columnBeingSorted.sortType : null;
+    const [columnBeingSorted, ...b] = columns.filter(c => c.accessor === column);
+    const type = (columnBeingSorted && columnBeingSorted.sortable !== false) ? columnBeingSorted.sortType : null;
 
     switch (direction) {
         case 'ascending':

--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -6,7 +6,7 @@ import { sortDirection } from '../assets/icons/Icon';
 
 const Column = ({ accessor, label, sortable, onClick, sort, icons }) => {
     const direction = sort.column === accessor ? sort.direction : 'none';
-    const icon = sortDirection({ direction, icons });
+    const icon = sortable ? sortDirection({ direction, icons }) : "";
     const sortFunction = sortable ? () => onClick({ column: accessor }) : () => {};
     const cssClass = `column-${accessor} ${ sortable ? 'clickable' : '' }`;
 

--- a/stories/index.js
+++ b/stories/index.js
@@ -15,6 +15,7 @@ import {
     customPaginationComponent,
     customIconProps,
     differentTheme,
+    unsorted,
 } from './props';
 
 
@@ -28,4 +29,5 @@ storiesOf('React Collapsing Table', module)
     .add('Only certain columns can be sorted on', () => <ReactCollapsingTable {...sortableColumnsProps} />)
     .add('Custom Text Input Pagination', () => <ReactCollapsingTable {...customPaginationComponent} />)
     .add('Custom Icons for the open/close row and de/ascending icon', () => <ReactCollapsingTable {...customIconProps} />)
+    .add('Columns with sort feature disabled', () => <ReactCollapsingTable {...unsorted} />)
     .add('Custom theme, no applied styles', () => <ReactCollapsingTable {...differentTheme} />);

--- a/stories/props.js
+++ b/stories/props.js
@@ -150,3 +150,11 @@ export const differentTheme = {
     rows: generateFakeData({ totalRows: 1000 }),
     theme: 'notTheDefault'
 };
+
+export const unsorted = {
+    columns: getColumns().map(column => {
+        column.sortable = false;
+        return column;
+    }),
+    rows: generateFakeData({ totalRows: 1000 })
+};


### PR DESCRIPTION
The sort function for columns can be disabled, but this wasn't mentioned in the documentation.