### PR TITLE
Add property to disable table collapsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-collapsing-table",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "react-collapsing-table: a React rewrite of the jQuery table plugin from 'datatables.net'. Inspired by a lack of similar table behaviors, notably collapsibility and responsivity.",
   "main": "build/index.js",
   "peerDependencies": {

--- a/src/__tests__/actions/ResizeTableActions.test.js
+++ b/src/__tests__/actions/ResizeTableActions.test.js
@@ -410,4 +410,37 @@ describe('Resize Table Actions', () => {
 
         expect(actions.addColumn(given)).toEqual(expected);
     });
+
+    it('should add all hidden columns if isCollapsible is false', () => {
+      const given = {
+        isCollapsible: false,
+        width: 149,
+        state: {
+          columns: [
+            { isVisible: true, minWidth: 100, priorityLevel: 1, position: 1, },
+            { isVisible: false, minWidth: 50, priorityLevel: 2, position: 2, },
+            { isVisible: false, minWidth: 90, priorityLevel: 3, position: 3, },
+          ],
+          rows: [
+            { isOpen: false, firstName: 'Paul', },
+            { isOpen: true, firstName: 'Matt', },
+            { isOpen: false, firstName: 'Michelle', },
+          ],
+        }
+      };
+      const expected = {
+          columns: [
+            { isVisible: true, minWidth: 100, priorityLevel: 1, position: 1, },
+            { isVisible: true, minWidth: 50, priorityLevel: 2, position: 2, },
+            { isVisible: true, minWidth: 90, priorityLevel: 3, position: 3, },
+          ],
+          rows: [
+            { isOpen: false, firstName: 'Paul', },
+            { isOpen: false, firstName: 'Matt', },
+            { isOpen: false, firstName: 'Michelle', },
+          ]
+      };
+  
+      expect(actions.resizeTable(given)).toEqual(expected);
+    });  
 });

--- a/src/__tests__/components/Table.test.js
+++ b/src/__tests__/components/Table.test.js
@@ -235,7 +235,7 @@ describe('Table', () => {
         expect(email.sortable).toBe(true);
     });
 
-    it('should allow to change columns after beeing mounted', () => {
+    it('should allow to change columns after being mounted', () => {
         wrapper = mount(<Table {...props} />)
         
         expect(wrapper.state().columns.length).toBe(3)
@@ -285,6 +285,23 @@ describe('Table', () => {
         instance.toggleSearchInputIcons(searchValue);
         expect(wrapper.state().showSearchIcon).toBe(false);
         expect(wrapper.state().showClearIcon).toBe(true);
+    });
+
+    it('should test Resize Table Actions is called when isCollapsible flag changes', () => {
+        wrapper = mount(<Table {...props} />)
+        
+        expect(wrapper.state().columns.length).toBe(3)
+        expect(wrapper.find('thead th')).toHaveLength(3)
+
+        // Now we set the isCollapsible flag to false
+        wrapper.setProps({ isCollapsible: false })
+
+        // Resize table is called
+        expect(resizeTableActions.resizeTable).toHaveBeenCalled();
+
+        // Table state should remain same
+        expect(wrapper.state().columns.length).toBe(3)
+        expect(wrapper.find('thead th')).toHaveLength(2)
     });
 
     describe('when server pagination is used', () => {

--- a/src/__tests__/components/Table.test.js
+++ b/src/__tests__/components/Table.test.js
@@ -301,7 +301,7 @@ describe('Table', () => {
 
         // Table state should remain same
         expect(wrapper.state().columns.length).toBe(3)
-        expect(wrapper.find('thead th')).toHaveLength(2)
+        expect(wrapper.find('thead th')).toHaveLength(3)
     });
 
     describe('when server pagination is used', () => {

--- a/src/actions/ResizeTableActions.js
+++ b/src/actions/ResizeTableActions.js
@@ -1,18 +1,40 @@
 import { dynamicSort } from './TableActions'
 
-export const resizeTable = ({ width, state }) => {
+export const resizeTable = ({ width, state, isCollapsible = true }) => {
     const { columns } = state;
     let visibleColumns = columns.filter(column => column.isVisible );
 
     let visibleColumnsWidth = 0;
     visibleColumns.map(column => visibleColumnsWidth += column.minWidth);
 
-    state = visibleColumnsWidth > width ?
-        tryToRemoveColumns({ visibleColumnsWidth, width, state }) :
-        tryToAddColumns({ visibleColumnsWidth, width, state });
+    if (isCollapsible) {
+        state = visibleColumnsWidth > width ? 
+                    tryToRemoveColumns({ visibleColumnsWidth, width, state }) :
+                    tryToAddColumns({ visibleColumnsWidth, width, state });
+    } else {
+        state = addAllColumns({ state });
+    }
 
     return state;
 };
+
+// Adds all hidden columns to the state irrespective of the available width
+export const addAllColumns = ({ state }) => {
+    const { columns } = state;
+    const hiddenColumns = Object.assign([], columns.filter(column => !column.isVisible));
+    hiddenColumns.sort(dynamicSort({column: 'priorityLevel'}));
+
+    while (hiddenColumns.length !== 0) {
+        hiddenColumns.shift();
+        if (hiddenColumns.length === 0) {
+            state = addColumn({ state });
+            state = closeAllRows({ state });
+        } else {
+            state = addColumn({ state })
+        }
+    }
+    return state
+}
 
 export const tryToRemoveColumns = ({ visibleColumnsWidth, width, state }) => {
     const { columns } = state;

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -38,6 +38,7 @@ export class Table extends Component {
             theme = 'react-collapsible-theme',
             showSearchIcon = true,
             showClearIcon = false,
+            isCollapsible = true,
         } = props;
 
         this.state = {
@@ -108,7 +109,7 @@ export class Table extends Component {
 
     componentDidUpdate(prevProps){
         if (prevProps.isCollapsible !== this.props.isCollapsible) {
-            this.resizeTable(this.props.isCollapsible)
+            this.resizeTable()
         }
     }
 
@@ -116,14 +117,10 @@ export class Table extends Component {
         window.removeEventListener('resize', this.resizeTable);
     }
 
-    resizeTable(isCollapsible = true) {
-        const { useContainerWidth } = this.state;
-        let width = window.innerWidth
-        if (useContainerWidth && this.tableRef.current) {
-            width = this.tableRef.current.getBoundingClientRect().width
-        }
+    resizeTable() {
+        const { isCollapsible } = this.props;
         this.setState(currentState => {
-            return resizeTable({ width, state: currentState, isCollapsible })
+            return resizeTable({ width: window.innerWidth, state: currentState, isCollapsible })
         })
     };
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -106,13 +106,24 @@ export class Table extends Component {
         })
     }
 
+    componentDidUpdate(prevProps){
+        if (prevProps.isCollapsible !== this.props.isCollapsible) {
+            this.resizeTable(this.props.isCollapsible)
+        }
+    }
+
     componentWillUnmount() {
         window.removeEventListener('resize', this.resizeTable);
     }
 
-    resizeTable() {
+    resizeTable(isCollapsible = true) {
+        const { useContainerWidth } = this.state;
+        let width = window.innerWidth
+        if (useContainerWidth && this.tableRef.current) {
+            width = this.tableRef.current.getBoundingClientRect().width
+        }
         this.setState(currentState => {
-            return resizeTable({ width: window.innerWidth, state: currentState })
+            return resizeTable({ width, state: currentState, isCollapsible })
         })
     };
 

--- a/stories/index.js
+++ b/stories/index.js
@@ -16,6 +16,7 @@ import {
     customIconProps,
     differentTheme,
     unsorted,
+    expandAllColumnsProps,
 } from './props';
 
 storiesOf('React Collapsing Table', module)
@@ -35,6 +36,7 @@ storiesOf('React Collapsing Table', module)
     .add('Columns with sort feature disabled', () => <ReactCollapsingTable {...unsorted} />)
     .add('Custom theme, no applied styles', () => <ReactCollapsingTable {...differentTheme} />)
     .add('Dynamic table columns', () => {
-        const dynamicColumns = basicTableProps.columns.filter(column => boolean(column.label, true))
+        const dynamicColumns = basicTableProps.columns.filter(column => !!column.label)
         return <ReactCollapsingTable {...basicTableProps} columns={dynamicColumns} />
-    });
+    })
+    .add('Expand all columns irrespective of available width', () => <ReactCollapsingTable {...expandAllColumnsProps} />);

--- a/stories/props.js
+++ b/stories/props.js
@@ -157,3 +157,9 @@ export const unsorted = {
     }),
     rows: generateFakeData({ totalRows: 1000 })
 };
+
+export const expandAllColumnsProps = {
+    columns: getColumns(),
+    rows: generateFakeData({ totalRows: 1000 }),
+    isCollapsible: false,
+};


### PR DESCRIPTION
### Problem
The collapsed view of the table works well for most use cases. However, some users might want to get a view of all the columns at once to analyse the table records. We encountered such a use case and thus this solution.

### Solution
Provide a `isCollapsible` flag/property that the client can use to opt-out of the collapsed view if required. This property is `true` be default. This flags enables the client to provide the user with an option to expand all the columns and analyse the table records much more conveniently.

### UI implications
Expanding the columns will lead to horizontal scrolling. 

