### PR TITLE
Added Colspan to td when there's no data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-collapsing-table",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "react-collapsing-table: a React rewrite of the jQuery table plugin from 'datatables.net'. Inspired by a lack of similar table behaviors, notably collapsibility and responsivity.",
   "main": "build/index.js",
   "peerDependencies": {

--- a/src/components/Rows.js
+++ b/src/components/Rows.js
@@ -31,7 +31,7 @@ const Rows = ({ rows, visibleColumns, hiddenColumns, expandRow, callbacks, icons
         return (
             <tbody>
                 <tr className="no-results">
-                    <td>Sorry, your search did not return any results. Please try again.</td>
+                    <td colSpan={visibleColumns.length}>Sorry, your search did not return any results. Please try again.</td>
                 </tr>
             </tbody>
         );


### PR DESCRIPTION
Hey, a small change to the td element, added a colspan that's equal to the visible columns. Now, the no data text takes up all the visible columns as well.